### PR TITLE
Fix horizontal scroll while the Instagram section loads

### DIFF
--- a/src/components/instagram/EmbedCards.tsx
+++ b/src/components/instagram/EmbedCards.tsx
@@ -1,11 +1,26 @@
 import { InstagramEmbed } from "react-social-media-embed";
 
+const POSTS = [
+    "https://www.instagram.com/p/DY7nCOllEhH/",
+    "https://www.instagram.com/reel/DYNXR5Mqr5K/",
+    "https://www.instagram.com/reel/DY0s7ZzKY6k/",
+];
+
 export default function EmbedCards() {
     return (
-        <div className='flex flex-col gap-4 items-center lg:justify-center lg:flex-row'>
-            <InstagramEmbed url="https://www.instagram.com/p/DY7nCOllEhH/" width={328} height={615} />
-            <InstagramEmbed url="https://www.instagram.com/reel/DYNXR5Mqr5K/" width={328} height={615} />
-            <InstagramEmbed url="https://www.instagram.com/reel/DY0s7ZzKY6k/" width={328} height={615} />
+        <div className='flex flex-col gap-4 items-center w-full lg:justify-center lg:flex-row'>
+            {POSTS.map((url) => (
+                // The wrapper caps the width at 328px and clips the transient
+                // over-width (Instagram's raw blockquote is up to 540px before
+                // embed.js processes it) that otherwise causes horizontal scroll.
+                // min-h reserves the space so the page doesn't jump while loading.
+                <div
+                    key={url}
+                    className="w-full max-w-[328px] min-h-[615px] overflow-hidden rounded-md bg-gray-50"
+                >
+                    <InstagramEmbed url={url} width="100%" />
+                </div>
+            ))}
         </div>
-    )
+    );
 }

--- a/src/components/instagram/Instagram.tsx
+++ b/src/components/instagram/Instagram.tsx
@@ -13,8 +13,8 @@ export default function Instagram() {
     const pathname = usePathname();
 
     return (
-        <section id='community' className='flex justify-center items-center px-3 lg:px-0'>
-            <div className='max-w-7xl mx-auto py-10'>
+        <section id='community' className='flex overflow-x-hidden justify-center items-center px-3 lg:px-0'>
+            <div className='max-w-7xl w-full mx-auto py-10'>
                 <h2 className="text-5xl lg:text-8xl font-bold text-shadow -tracking-[4px] lg:-tracking-[6px] py-20 text-center" style={{ lineHeight: 0.8 }}>
                     {pathname === '/en' ? textEn : textEs}
                 </h2>


### PR DESCRIPTION
  Before embed.js processed them, Instagram''s raw blockquotes rendered
  up
  to 540px wide, overflowing the viewport and causing horizontal scroll
  until the embeds settled (the body''s overflow-x-hidden was
  ineffective
  because the real scroller is <html>).

  - Wrap each embed in a responsive container (w-full, max-w-[328px], overflow-hidden) that caps the width and clips the transient over-width, and use width="100%" on the embed so it adapts on mobile instead of forcing a fixed 328px.
  - Reserve the height with min-h-[615px] so the page no longer jumps as the embeds load (skeleton-like stable space).
  - Add overflow-x-hidden to the Instagram section as a safety net.